### PR TITLE
Optimization as well as fixing a few things

### DIFF
--- a/common/src/main/java/com/iafenvoy/tooltipsreforged/component/DurabilityComponent.java
+++ b/common/src/main/java/com/iafenvoy/tooltipsreforged/component/DurabilityComponent.java
@@ -42,17 +42,24 @@ public class DurabilityComponent implements TooltipComponent {
     @Override
     public int getHeight() {
         if (this.isDurabilityDisabled()) return 0;
-        return TooltipReforgedConfig.INSTANCE.common.durabilityTooltip.getValue() ? 14 : 9;
+        return TooltipReforgedConfig.INSTANCE.common.durabilityTooltip.getValue() ? 13 : 9;
     }
 
     @Override
     public int getWidth(TextRenderer textRenderer) {
         if (this.isDurabilityDisabled()) return 0;
         int durabilityTextWidth = textRenderer.getWidth(Text.translatable("tooltip.%s.durability".formatted(TooltipReforgedClient.MOD_ID)));
-        if (TooltipReforgedConfig.INSTANCE.common.durabilityTooltip.getValue())
-            return durabilityTextWidth + SPACING + WIDTH + 1;
-        Text durability = this.getDurabilityText();
-        return durabilityTextWidth + textRenderer.getWidth(durability);
+        if (TooltipReforgedConfig.INSTANCE.common.durabilityTooltip.getValue()) {
+            if (TooltipReforgedConfig.INSTANCE.common.durabilityBackground.getValue()) {
+                return durabilityTextWidth + SPACING + WIDTH - 5;
+            } else {
+                Text durability = this.getDurabilityText();
+                return durabilityTextWidth + SPACING + textRenderer.getWidth(durability) - 9;
+            }
+        } else {
+            Text durability = this.getDurabilityText();
+            return durabilityTextWidth + textRenderer.getWidth(durability);
+        }
     }
 
     @Override
@@ -63,19 +70,19 @@ public class DurabilityComponent implements TooltipComponent {
         int textHeight = textRenderer.fontHeight;
         int textY = TooltipReforgedConfig.INSTANCE.common.durabilityTooltip.getValue() ? y - textHeight + SPACING * 2 + 2 : y;
         context.drawText(textRenderer, Text.translatable("tooltip.%s.durability".formatted(TooltipReforgedClient.MOD_ID)), x, textY, 0xffffffff, true);
-        x += textRenderer.getWidth(Text.translatable("tooltip.%s.durability".formatted(TooltipReforgedClient.MOD_ID))) + SPACING;
+        x += textRenderer.getWidth(Text.translatable("tooltip.%s.durability".formatted(TooltipReforgedClient.MOD_ID))) + SPACING - 4;
 
         int damaged = this.stack.getMaxDamage() - this.stack.getDamage();
         Text durabilityText = this.getDurabilityText();
         int color = BadgesUtils.darkenColor(0xff000000 | this.stack.getItemBarColor(), 0.9f);
         boolean enhanced = TooltipReforgedConfig.INSTANCE.common.durabilityTooltip.getValue() && TooltipReforgedConfig.INSTANCE.common.durabilityBackground.getValue();
         if (enhanced) {
-            context.fill(x, textY - SPACING / 2, x + (damaged * WIDTH) / this.stack.getMaxDamage(), textY + textHeight, color);
-            BadgesUtils.drawFrame(context, x, textY - SPACING / 2, WIDTH, textHeight + SPACING, 400, BadgesUtils.darkenColor(0xff000000 | this.stack.getItemBarColor(), 0.8f));
+            context.fill(x, textY - SPACING / 2 + 1, x + (damaged * WIDTH) / this.stack.getMaxDamage(), textY + textHeight - 1, color);
+            BadgesUtils.drawFrame(context, x, textY - SPACING / 2 + 1, WIDTH, textHeight + SPACING - 2, 400, BadgesUtils.darkenColor(0xff000000 | this.stack.getItemBarColor(), 0.8f));
         } else
             durabilityText = durabilityText.copy().setStyle(Style.EMPTY.withColor(color));
         if (!durabilityText.equals(Text.empty())) {
-            int textX = enhanced ? x + ((WIDTH - textRenderer.getWidth(durabilityText)) / 2) : x - SPACING;
+            int textX = enhanced ? x + ((WIDTH - textRenderer.getWidth(durabilityText)) / 2) - 1 : x - 4;
             context.drawText(textRenderer, durabilityText, textX, textY, 0xFFFFFFFF, true);
         }
     }

--- a/common/src/main/java/com/iafenvoy/tooltipsreforged/component/FoodEffectComponent.java
+++ b/common/src/main/java/com/iafenvoy/tooltipsreforged/component/FoodEffectComponent.java
@@ -70,8 +70,17 @@ public class FoodEffectComponent implements TooltipComponent {
 
         if (!TooltipReforgedConfig.INSTANCE.common.effectsTooltip.getValue()) return foodWidth + 4;
         if (foodComponent == null) return 0;
-        for (Pair<StatusEffectInstance, Float> effect : foodComponent.getStatusEffects())
-            effectsWidth = Math.max(effectsWidth, textRenderer.getWidth(Text.translatable(effect.getFirst().getTranslationKey()).append(" ").append(TextUtil.getDurationText(effect.getFirst(), 1.0f))) + 10);
+        for (Pair<StatusEffectInstance, Float> effect : foodComponent.getStatusEffects()) {
+            StatusEffectInstance statusEffect = effect.getFirst();
+            String text = Text.translatable(statusEffect.getTranslationKey()).getString();
+            if (statusEffect.getAmplifier() > 0) {
+                text = Text.translatable("potion.withAmplifier",text,Text.translatable("potion.potency." + statusEffect.getAmplifier()).getString()).getString();
+            }
+            if (!statusEffect.isDurationBelow(20)) {
+                text += " " + TextUtil.getDurationText(statusEffect, 1.0f).getString();
+            }
+            effectsWidth = Math.max(effectsWidth, textRenderer.getWidth(text) + 14);
+        }
         return Math.max(foodWidth, effectsWidth) + 4;
     }
 
@@ -110,12 +119,21 @@ public class FoodEffectComponent implements TooltipComponent {
             Sprite effectTexture = MinecraftClient.getInstance().getStatusEffectSpriteManager().getSprite(statusEffect.getEffectType());
             if (c == 0) c = 0xFF5454FC;
 
-            Text effectText = Text.translatable(statusEffect.getTranslationKey()).append(" (").append(TextUtil.getDurationText(statusEffect, 1.0f)).append(")");
+            String effectName = Text.translatable(statusEffect.getTranslationKey()).getString();
+            if (statusEffect.getAmplifier() > 0) {
+                effectName = Text.translatable("potion.withAmplifier", effectName, Text.translatable("potion.potency." + statusEffect.getAmplifier()).getString()).getString();
+            }
+            String fullText = effectName;
+            if (!statusEffect.isDurationBelow(20)) {
+                fullText += " (" + TextUtil.getDurationText(statusEffect, 1.0f).getString() + ")";
+            }
+            Text renderText = Text.literal(fullText);
             if (TooltipReforgedConfig.INSTANCE.common.effectsIcon.getValue()) {
                 context.drawSprite(x - 1, lineY - 1, 0, textRenderer.fontHeight, textRenderer.fontHeight, effectTexture);
-                context.drawText(textRenderer, effectText, x + textRenderer.fontHeight + 2, lineY, c, true);
-            } else
-                context.drawText(textRenderer, effectText, x, lineY, c, true);
+                context.drawText(textRenderer, renderText, x + textRenderer.fontHeight + 2, lineY, c, true);
+            } else {
+                context.drawText(textRenderer, renderText, x, lineY, c, true);
+            }
             lineY += textRenderer.fontHeight + 1;
         }
     }

--- a/common/src/main/java/com/iafenvoy/tooltipsreforged/component/HeaderComponent.java
+++ b/common/src/main/java/com/iafenvoy/tooltipsreforged/component/HeaderComponent.java
@@ -33,7 +33,7 @@ public class HeaderComponent implements TooltipComponent {
 
     @Override
     public int getHeight() {
-        return TEXTURE_SIZE + 4;
+        return TEXTURE_SIZE + 2;
     }
 
     @Override
@@ -45,9 +45,9 @@ public class HeaderComponent implements TooltipComponent {
         if (TooltipReforgedConfig.INSTANCE.common.itemGroupTooltip.getValue())
             badgeWidth = textRenderer.getWidth(badgeText) + SPACING * 2;
         if (TooltipReforgedConfig.INSTANCE.common.rarityTooltip.getValue())
-            titleWidth = textRenderer.getWidth(this.nameText) + badgeWidth;
+            titleWidth = textRenderer.getWidth(this.nameText) + badgeWidth + 2;
         else titleWidth = Math.max(textRenderer.getWidth(this.nameText), badgeWidth);
-        return Math.max(titleWidth, rarityWidth) + this.getTitleOffset() + (this.getTitleOffset() - TEXTURE_SIZE) / 2 + 2;
+        return Math.max(titleWidth, rarityWidth) + this.getTitleOffset() + (this.getTitleOffset() - TEXTURE_SIZE) / 2 - 3;
     }
 
     public int getTitleOffset() {
@@ -58,10 +58,10 @@ public class HeaderComponent implements TooltipComponent {
     public void drawText(TextRenderer textRenderer, int x, int y, Matrix4f matrix, VertexConsumerProvider.Immediate vertexConsumers) {
         float startDrawX = (float) x + this.getTitleOffset();
         float startDrawY = y + 1;
-        textRenderer.draw(this.nameText, startDrawX, startDrawY - 2, -1, true, matrix, vertexConsumers, TextRenderer.TextLayerType.NORMAL, 0, 0xF000F0);
+        textRenderer.draw(this.nameText, startDrawX, startDrawY - 1, -1, true, matrix, vertexConsumers, TextRenderer.TextLayerType.NORMAL, 0, 0xF000F0);
 
         if (TooltipReforgedConfig.INSTANCE.common.rarityTooltip.getValue()) {
-            startDrawY += textRenderer.fontHeight + SPACING;
+            startDrawY += textRenderer.fontHeight + 2;
             textRenderer.draw(this.rarityName, startDrawX, startDrawY, -1, true, matrix, vertexConsumers, TextRenderer.TextLayerType.NORMAL, 0, 0xF000F0);
         }
     }
@@ -72,10 +72,10 @@ public class HeaderComponent implements TooltipComponent {
         int startDrawY = y + (TEXTURE_SIZE - ITEM_MODEL_SIZE) / 2;
         context.drawItem(this.stack, startDrawX, startDrawY);
         int color = TooltipReforgedConfig.INSTANCE.common.itemBorderColor.getValue();
-        TooltipsRenderHelper.renderVerticalLine(context, startDrawX - 3, startDrawY - 2, 21, 21, color);
-        TooltipsRenderHelper.renderVerticalLine(context, startDrawX + 19, startDrawY - 2, 21, 0, color);
-        TooltipsRenderHelper.renderHorizontalLine(context, startDrawX - 2, startDrawY - 3, 21, 0, color);
-        TooltipsRenderHelper.renderHorizontalLine(context, startDrawX - 2, startDrawY + 19, 21, 0, color);
+        TooltipsRenderHelper.renderVerticalLine(context, startDrawX - 3, startDrawY - 2, 20, 21, color);
+        TooltipsRenderHelper.renderVerticalLine(context, startDrawX + 18, startDrawY - 2, 20, 0, color);
+        TooltipsRenderHelper.renderHorizontalLine(context, startDrawX - 2, startDrawY - 3, 20, 0, color);
+        TooltipsRenderHelper.renderHorizontalLine(context, startDrawX - 2, startDrawY + 18, 20, 0, color);
 
         if (!TooltipReforgedConfig.INSTANCE.common.itemGroupTooltip.getValue()) return;
         Pair<Text, Integer> badgeText = BadgesUtils.getBadgeText(this.stack);
@@ -84,11 +84,11 @@ public class HeaderComponent implements TooltipComponent {
 
     private void drawBadge(TextRenderer textRenderer, Text text, int x, int y, DrawContext context, int fillColor) {
         int textWidth = textRenderer.getWidth(text);
-        int textHeight = textRenderer.fontHeight;
+        int textHeight = textRenderer.fontHeight - 2;
         int textX = x + this.getTitleOffset() + (TooltipReforgedConfig.INSTANCE.common.rarityTooltip.getValue() ? textRenderer.getWidth(this.nameText) + SPACING + 2 : 4);
-        int textY = (TooltipReforgedConfig.INSTANCE.common.rarityTooltip.getValue() ? y : y + 12) - textRenderer.fontHeight + SPACING * 2 + 3;
+        int textY = (TooltipReforgedConfig.INSTANCE.common.rarityTooltip.getValue() ? y : y + 12) - textRenderer.fontHeight + SPACING * 2 + 4;
         context.fill(textX - SPACING, textY - SPACING / 2, textX + textWidth + SPACING, textY + textHeight, BadgesUtils.darkenColor(fillColor, 0.9f));
-        context.drawText(textRenderer, text, textX, textY, 0xffffffff, true);
+        context.drawText(textRenderer, text, textX, textY - 1, 0xffffffff, true);
         BadgesUtils.drawFrame(context, textX - SPACING, textY - SPACING / 2, textWidth + SPACING * 2, textHeight + SPACING, 400, BadgesUtils.darkenColor(fillColor, 0.8f));
     }
 }

--- a/common/src/main/java/com/iafenvoy/tooltipsreforged/component/PotionEffectsComponent.java
+++ b/common/src/main/java/com/iafenvoy/tooltipsreforged/component/PotionEffectsComponent.java
@@ -38,8 +38,16 @@ public class PotionEffectsComponent implements TooltipComponent {
     @Override
     public int getWidth(TextRenderer textRenderer) {
         int effectsWidth = 0;
-        for (StatusEffectInstance effect : this.getPotionEffects())
-            effectsWidth = Math.max(effectsWidth, textRenderer.getWidth(Text.translatable(effect.getTranslationKey()).append(" ").append(TextUtil.getDurationText(effect, this.durationMultiplier))) + 10);
+        for (StatusEffectInstance effect : this.getPotionEffects()) {
+            String text = Text.translatable(effect.getTranslationKey()).getString();
+            if (effect.getAmplifier() > 0) {
+                text = Text.translatable("potion.withAmplifier", text, Text.translatable("potion.potency." + effect.getAmplifier()).getString()).getString();
+            }
+            if (!effect.isDurationBelow(20)) {
+                text += " " + TextUtil.getDurationText(effect, this.durationMultiplier).getString();
+            }
+            effectsWidth = Math.max(effectsWidth, textRenderer.getWidth(text) + 14);
+        }
         return effectsWidth + 4;
     }
 
@@ -54,8 +62,10 @@ public class PotionEffectsComponent implements TooltipComponent {
             Text mutableText = Text.translatable(effect.getTranslationKey());
             if (effect.getAmplifier() > 0)
                 mutableText = Text.translatable("potion.withAmplifier", mutableText, Text.translatable("potion.potency." + effect.getAmplifier()));
-            if (!effect.isDurationBelow(20))
-                mutableText = Text.translatable("potion.withDuration", mutableText, TextUtil.getDurationText(effect, this.durationMultiplier));
+            if (!effect.isDurationBelow(20)) {
+                String durationText = TextUtil.getDurationText(effect, this.durationMultiplier).getString();
+                mutableText = Text.literal(mutableText.getString() + " (" + durationText + ")");
+            }
             lineY += textRenderer.fontHeight + 1;
             if (TooltipReforgedConfig.INSTANCE.common.effectsIcon.getValue()) {
                 context.drawSprite(x - 1, lineY - 1, 0, textRenderer.fontHeight, textRenderer.fontHeight, effectTexture);

--- a/common/src/main/java/com/iafenvoy/tooltipsreforged/util/TextUtil.java
+++ b/common/src/main/java/com/iafenvoy/tooltipsreforged/util/TextUtil.java
@@ -120,7 +120,7 @@ public final class TextUtil {
     }
 
     public static Text getDurationText(StatusEffectInstance effect, float multiplier) {
-        if (effect.isInfinite() || effect.getDuration() >= 60 * 100) {
+        if (effect.isInfinite() || effect.getDuration() >= 60 * 1200) {
             return Text.translatable("effect.duration.infinite");
         } else {
             int i = MathHelper.floor((float) effect.getDuration() * multiplier);


### PR DESCRIPTION
调整：
物品名位置
物品边框大小
模组名和耐久度的位置和背景大小
工具提示框各功能的边距
状态效果持续时间无限的显示判定
工具提示框的药水状态效果宽度判定
食物附加的状态效果的等级显示
统一状态效果持续时间的括号样式

对比图（左边是原来的 右边是改过的）：
<img width="778" height="1664" alt="未标题-1" src="https://github.com/user-attachments/assets/08836826-ea0c-4332-b8b5-b6731af2b514" />
